### PR TITLE
Add new property to facilitate connecting payments to balance activities (NOXT-29910)

### DIFF
--- a/v4/schema/Customer/AccountBalanceTelia.yaml
+++ b/v4/schema/Customer/AccountBalanceTelia.yaml
@@ -16,3 +16,6 @@ allOf:
       paymentId:
         type: string
         description: Identifier of payment
+      uniqueId:
+        type: string
+        description: The unique ID of the payment that changed balance

--- a/v4/schema/Payment/PaymentTelia.yaml
+++ b/v4/schema/Payment/PaymentTelia.yaml
@@ -10,3 +10,6 @@ allOf:
       bankAccountNumber:
         type: string
         description: The originating bank account number of the payment
+      uniqueId:
+        type: string
+        description: The unique ID of the payment


### PR DESCRIPTION
Salesforce B2C needs a unique ID to be able to connect up balance activities with payments. (These both originate from the balance activities operation in CBM).

Due to concerns with backwards compatibility, the suggestion is to keep the existing `id`/`paymentId` fields as-is, even though they are now known not to be unique.